### PR TITLE
use a fixed version of resilio sync whilst 2.5 is broken on alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
+# package verions
+ARG SYNC_VER="2.4.5"
+
 # install packages
 RUN \
  apk add --no-cache \
@@ -16,18 +19,18 @@ RUN \
 # install resilio
  curl -o \
  /tmp/sync.tar.gz -L \
-	https://download-cdn.resilio.com/stable/linux-armhf/resilio-sync_armhf.tar.gz && \
+	"https://download-cdn.getsync.com/${SYNC_VER}/linux-armhf/resilio-sync_armhf.tar.gz" && \
  tar xf \
  /tmp/sync.tar.gz \
 	-C /usr/bin && \
 
-# cleanup
+# cleanup
  rm -rf \
 	/tmp/*
 
-# add local files
+# add local files
 COPY root/ /
 
-# ports and volumes
+# ports and volumes
 EXPOSE 8888 55555
 VOLUME /config /sync

--- a/README.md
+++ b/README.md
@@ -77,5 +77,6 @@ In this instance `PUID=1001` and `PGID=1001`. To find yours use `id user` as bel
 
 ## Versions
 
++ **14.05.17:** Use fixed version instead of latest, while 2.5.0 is broken on non glibc (alpine).
 + **08.02.17:** Rebase to alpine 3.5.
 + **02.11.16:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ 2.5 (latest version) is currently broken and calling for glibc symbols for the non glibc version
+ using fixed version 2.4.5 until this is resolved but allowing for update of dependencies etc.